### PR TITLE
Snippet placeholder proposals fix

### DIFF
--- a/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/completion/LSIncompleteCompletionProposal.java
+++ b/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/completion/LSIncompleteCompletionProposal.java
@@ -498,7 +498,7 @@ class LSIncompleteCompletionProposal
                         }
                         insertText = insertText.substring(0, currentSnippetOffsetInInsertText) + defaultProposal + insertText.substring(currentSnippetOffsetInInsertText + offsetInSnippet);
                         LinkedPosition position = null;
-                        if (!snippetProposals.isEmpty()) {
+                        if (isChoice && !snippetProposals.isEmpty()) {
                             int replacementOffset = insertionOffset + currentSnippetOffsetInInsertText;
                             ICompletionProposal[] proposals = snippetProposals.stream().map(string ->
                             new CompletionProposal(string, replacementOffset, defaultProposal.length(), replacementOffset + string.length())


### PR DESCRIPTION
When snippet proposal has placeholder lxtk shows it as single choice proposal.
For example:
```let ${1:name} = $0```
gives you a popup with single proposal `name` and applies on Enter, but it should show you selected default value. Current implementation processes it as choice proposal, ex:
```let ${1|name|} = $0```
