### PR TITLE
If editor has text selection - replace selection with new text

### DIFF
--- a/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/completion/LSIncompleteCompletionProposal.java
+++ b/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/completion/LSIncompleteCompletionProposal.java
@@ -30,6 +30,7 @@ import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.text.contentassist.BoldStylerProvider;
 import org.eclipse.jface.text.contentassist.CompletionProposal;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
@@ -44,6 +45,7 @@ import org.eclipse.jface.text.link.LinkedModeUI;
 import org.eclipse.jface.text.link.LinkedPosition;
 import org.eclipse.jface.text.link.LinkedPositionGroup;
 import org.eclipse.jface.text.link.ProposalPosition;
+import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.jface.viewers.StyledString.Styler;
 import org.eclipse.lsp4j.CompletionItem;
@@ -526,7 +528,13 @@ class LSIncompleteCompletionProposal
                 allEdits.addAll(additionalEdits);
                 DocumentUtil.applyEdits(document, allEdits);
             } else {
-                DocumentUtil.applyEdit(document, textEdit);
+                ISelection viewerSelection = viewer.getSelectionProvider().getSelection();
+                if (viewerSelection instanceof TextSelection) {
+                    TextSelection textSelection = (TextSelection)viewerSelection;
+                    DocumentUtil.applyEditWithSelection(document, textEdit, textSelection.getOffset(), textSelection.getLength());
+                } else {
+                    DocumentUtil.applyEdit(document, textEdit);
+                }
             }
 
             if (viewer != null && !regions.isEmpty()) {

--- a/org.lxtk.lx4e/src/org/lxtk/lx4e/DocumentUtil.java
+++ b/org.lxtk.lx4e/src/org/lxtk/lx4e/DocumentUtil.java
@@ -118,6 +118,40 @@ public class DocumentUtil
     }
 
     /**
+     * Applies the given LSP text edit to the given document.
+     *
+     * @param document not <code>null</code>
+     * @param edit an LSP text edit to apply to the document
+     *  (not <code>null</code>)
+     * @param selectionOffset current text selection offset or -1 if there is no text selection
+     * @param selectionLength current text selection length. not negative number.
+     * @throws BadLocationException if the specified edit range is invalid
+     *  in the document
+     */
+    public static void applyEditWithSelection(IDocument document, TextEdit edit, int selectionOffset,
+        int selectionLength) throws BadLocationException
+    {
+        IRegion r = toRegion(document, edit.getRange());
+        int finalOffset = r.getOffset();
+        int finalLength = r.getLength();
+
+        if (selectionLength > 0 && selectionOffset > -1)
+        {
+            if (selectionOffset < finalOffset)
+            {
+                finalOffset = selectionOffset;
+                finalLength = r.getOffset() - selectionOffset;
+            }
+            if (selectionLength > 0)
+            {
+                finalLength += selectionLength;
+            }
+        }
+
+        document.replace(finalOffset, finalLength, edit.getNewText());
+    }
+
+    /**
      * Applies the given sequence of LSP text edits to the given document
      * as a single document modification.
      *


### PR DESCRIPTION
Now completion replaces selected area when proposal is applied