### PR TITLE
Fix #16 - Diagnostics should use correct serializer adapter

### DIFF
--- a/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/codeaction/AbstractMarkerResolutionGenerator.java
+++ b/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/codeaction/AbstractMarkerResolutionGenerator.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Vladimir Piskarev (1C) - initial API and implementation
+ *     Alexander Kozinko (1C)
  *******************************************************************************/
 package org.lxtk.lx4e.ui.codeaction;
 

--- a/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/codeaction/AbstractQuickAssistProcessor.java
+++ b/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/codeaction/AbstractQuickAssistProcessor.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Vladimir Piskarev (1C) - initial API and implementation
+ *     Alexander Kozinko (1C)
  *******************************************************************************/
 package org.lxtk.lx4e.ui.codeaction;
 

--- a/org.lxtk.lx4e/src/org/lxtk/lx4e/diagnostics/DiagnosticMarkers.java
+++ b/org.lxtk.lx4e/src/org/lxtk/lx4e/diagnostics/DiagnosticMarkers.java
@@ -9,6 +9,7 @@
  *
  * Contributors:
  *     Vladimir Piskarev (1C) - initial API and implementation
+ *     Alexander Kozinko (1C)
  *******************************************************************************/
 package org.lxtk.lx4e.diagnostics;
 


### PR DESCRIPTION
We can add `EitherTypeAdapter` in gson to serialize diagnostics in marker.
`Gson` is properly initialized in lsp4j.jsonrpc [here](https://github.com/eclipse/lsp4j/blob/master/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler.java#L78)

We can use only Either adapter or we can add all adapter for safety. Or we can use something like
`new MessageJsonHandler(Map.of()).getDefaultGsonBuilder().create()` for consistency.