### PR TITLE
Fix different workspace folders with same length

### DIFF
--- a/org.lxtk/src/org/lxtk/DefaultWorkspaceService.java
+++ b/org.lxtk/src/org/lxtk/DefaultWorkspaceService.java
@@ -55,7 +55,8 @@ public class DefaultWorkspaceService
         if (newFolders != null && !newFolders.isEmpty())
         {
             newSortedFolders =
-                new TreeMap<>(Comparator.comparingInt((String s) -> s.length()).reversed());
+                new TreeMap<>(Comparator.comparingInt((String s) -> s.length()).thenComparing(
+                    String::compareTo).reversed());
             dryRun(newFolders, newSortedFolders);
         }
 


### PR DESCRIPTION
If i had different projects where the uri has the same length then i got the following error:
```
Caused by: java.lang.IllegalArgumentException: Two or more workspace folders have the same URI: {karaf: file:/home/hetzge/git/karaf} and {helix: file:/home/hetzge/git/helix}
	at org.lxtk.DefaultWorkspaceService.dryRun(DefaultWorkspaceService.java:96)
	at org.lxtk.DefaultWorkspaceService.setWorkspaceFolders(DefaultWorkspaceService.java:59)
	at org.lxtk.lx4e.WorkspaceFoldersManager.lambda$0(WorkspaceFoldersManager.java:68)
	at org.lxtk.util.SafeRun.lambda$0(SafeRun.java:47)
	at org.lxtk.util.SafeRun.runWithResult(SafeRun.java:64)
	at org.lxtk.util.SafeRun.run(SafeRun.java:45)
	at org.lxtk.lx4e.WorkspaceFoldersManager.startup(WorkspaceFoldersManager.java:55)
	at de.hetzge.eclipse.scala.Activator.lambda$1(Activator.java:73)
	at org.lxtk.util.SafeRun.lambda$0(SafeRun.java:47)
	at org.lxtk.util.SafeRun.runWithResult(SafeRun.java:64)
	at org.lxtk.util.SafeRun.run(SafeRun.java:45)
	at de.hetzge.eclipse.scala.Activator.start(Activator.java:71)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$2.run(BundleContextImpl.java:818)
	at org.eclipse.osgi.internal.framework.BundleContextImpl$2.run(BundleContextImpl.java:1)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:571)
	at org.eclipse.osgi.internal.framework.BundleContextImpl.startActivator(BundleContextImpl.java:810)
	... 128 more
```
With this fix the projects should be handled as different projects.