### PR TITLE
Fix duplicate entries in workspace symbols dialog

### DIFF
--- a/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/symbols/WorkspaceSymbolItem.java
+++ b/org.lxtk.lx4e.ui/src/org/lxtk/lx4e/ui/symbols/WorkspaceSymbolItem.java
@@ -213,4 +213,23 @@ public class WorkspaceSymbolItem
         request.setMayThrow(false);
         return request.sendAndReceive();
     }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(this.symbol);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        final WorkspaceSymbolItem other = (WorkspaceSymbolItem)obj;
+        return Objects.equals(this.symbol, other.symbol);
+    }
 }


### PR DESCRIPTION
If i have multiple projects, each with a separate LSP Server instance running, then the Workspace Symbols dialog shows the elements also multiple times.

![Screenshot_20241217_002507](https://github.com/user-attachments/assets/e57d4218-1216-47f7-b041-53c893ed92d3)

I debugged that down to the point where the entries are added to a Set. Therefore my idea is to implement hashcode/equals. This solves my problem:

![Screenshot_20241217_000534](https://github.com/user-attachments/assets/d83682aa-9a6b-4bbb-83ed-d2bc447c306f)

I am not sure if this is the best solution. Otherwise I think I have to implement my own WorkspaceSymbolProvider that merges multiple WorkspaceSymbolProviders together.